### PR TITLE
Add substring-before() and substring-after()

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -344,6 +344,16 @@ public class XPathFuncExpr extends XPathExpression {
             }
         } else if (name.equals("substr") && (args.length == 2 || args.length == 3)) {
             return substring(argVals[0], argVals[1], args.length == 3 ? argVals[2] : null);
+        } else if (name.equals("substring-before") && args.length == 2) {
+            String str = toString(argVals[0]);
+            String substr = toString(argVals[1]);
+            int pos = str.indexOf(substr);
+            return (pos >= 0 ? str.substring(0, pos) : ""); // empty string if not found
+        } else if (name.equals("substring-after") && args.length == 2) {
+            String str = toString(argVals[0]);
+            String substr = toString(argVals[1]);
+            int pos = str.indexOf(substr);
+            return (pos >= 0 ? str.substring(pos + substr.length()) : ""); // empty string if not found
         } else if (name.equals("contains") && args.length == 2) {
             return toString(argVals[0]).contains(toString(argVals[1]));
         } else if (name.equals("starts-with") && args.length == 2) {


### PR DESCRIPTION
Closes https://forum.opendatakit.org/t/add-xpath-substring-before-and-substring-after-functions/16863

#### What has been done to verify that this works as intended?
tested under Android Studio simulator running ODK Collect v1.18.0 (dirty), using test examples described on http://www.xsltfunctions.com/xsl/fn_substring-before.html and http://www.xsltfunctions.com/xsl/fn_substring-after.html, and compared results running same against Enketo.

#### Why is this the best possible solution? Were any other approaches considered?
Implements XPath standardized functions (which is arguably best solution). Implements identical XPath behavior as exists already in Enketo and libxml2.

#### Are there any risks to merging this code? If so, what are they?
Introduces entirely new XPath functions and does not touch or modify any existing javaRosa function or behavior. Can only be used by new forms that exploit these new functions in their XPath expressions, so no risk to existing forms.